### PR TITLE
Fix router response with malformed devices list

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "es.masorange.livebox.sdk"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 6
-        versionName = "1.1.4"
+        versionCode = 7
+        versionName = "1.1.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/network/NetworkDIModule.kt
+++ b/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/network/NetworkDIModule.kt
@@ -7,6 +7,7 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import es.masorange.livebox.sdk.di.BaseDIModule
 import es.masorange.livebox.sdk.network.adapters.AccessPointBandwidthConfAdapter
 import es.masorange.livebox.sdk.network.adapters.AccessPointTypeAdapter
+import es.masorange.livebox.sdk.network.adapters.DeviceInfoListAdapterFactory
 import es.masorange.livebox.sdk.network.adapters.FeatureIdAdapter
 import es.masorange.livebox.sdk.network.adapters.GeneralInfoAdapterFactory
 import es.masorange.livebox.sdk.network.adapters.MoshiBigDecimalAdapter
@@ -79,6 +80,7 @@ object NetworkDIModule : BaseDIModule() {
             Moshi.Builder()
                 .add(ShortAccessPointAdapter())
                 .add(GeneralInfoAdapterFactory())
+                .add(DeviceInfoListAdapterFactory())
                 .add(KotlinJsonAdapterFactory())
                 .add(FeatureIdAdapter())
                 .add(AccessPointTypeAdapter())

--- a/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/network/adapters/DeviceInfoListAdapter.kt
+++ b/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/network/adapters/DeviceInfoListAdapter.kt
@@ -1,0 +1,59 @@
+package es.masorange.livebox.sdk.network.adapters
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import es.masorange.livebox.sdk.domain.livebox.models.DeviceInfo
+import timber.log.Timber
+import java.lang.reflect.Type
+
+/**
+ * A [JsonAdapter.Factory] for [List]<[DeviceInfo]> that handles malformed JSON objects
+ * by skipping them instead of failing the entire parsing.
+ *
+ * This adapter is needed because some Livebox responses may contain malformed device objects
+ * where field values are missing, causing field names and values to be incorrectly shifted.
+ *
+ * When a malformed object is encountered, it is logged and skipped, allowing the rest
+ * of the valid devices to be parsed successfully.
+ */
+class DeviceInfoListAdapterFactory : JsonAdapter.Factory {
+    override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
+        val rawType = Types.getRawType(type)
+        if (rawType != List::class.java) return null
+
+        val elementType = Types.collectionElementType(type, List::class.java)
+        if (Types.getRawType(elementType) != DeviceInfo::class.java) return null
+
+        val deviceInfoAdapter = moshi.adapter<DeviceInfo>(elementType, annotations)
+        return DeviceInfoListAdapter(deviceInfoAdapter)
+    }
+}
+
+private class DeviceInfoListAdapter(
+    private val deviceInfoAdapter: JsonAdapter<DeviceInfo>
+) : JsonAdapter<List<DeviceInfo>>() {
+
+    override fun fromJson(reader: JsonReader): List<DeviceInfo> {
+        val devices = mutableListOf<DeviceInfo>()
+        reader.beginArray()
+        while (reader.hasNext()) {
+            try {
+                deviceInfoAdapter.fromJson(reader)?.let { devices.add(it) }
+            } catch (e: Exception) {
+                reader.skipValue()
+                Timber.w("Skipping malformed device: ${e.message}")
+            }
+        }
+        reader.endArray()
+        return devices
+    }
+
+    override fun toJson(writer: JsonWriter, value: List<DeviceInfo>?) {
+        writer.beginArray()
+        value?.forEach { deviceInfoAdapter.toJson(writer, it) }
+        writer.endArray()
+    }
+}

--- a/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/network/interceptors/LiveboxSdkHeadersInterceptor.kt
+++ b/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/network/interceptors/LiveboxSdkHeadersInterceptor.kt
@@ -7,7 +7,6 @@ internal const val ACCEPT_HEADER = "Accept"
 internal const val HOST_HEADER = "Host"
 internal const val ACCEPT_ENCODING_HEADER = "Accept-Encoding"
 internal const val USER_AGENT_HEADER = "User-Agent"
-internal const val CONNECTION_HEADER = "Connection"
 
 /**
  *  [Interceptor] that attaches Livebox headers for requests.
@@ -21,7 +20,6 @@ internal class LiveboxSdkHeadersInterceptor(val host: String) : Interceptor {
             .header(HOST_HEADER, host)
             .header(ACCEPT_ENCODING_HEADER, "gzip")
             .header(USER_AGENT_HEADER, "okhttp/4.12.0")
-            .header(CONNECTION_HEADER, "keep-alive")
             .build()
 
         return chain.proceed(newRequest)


### PR DESCRIPTION
There's a case in which a router can send a malformed list of connected devices. For some reason, we found a list with the following device `{"physAddress":"14:AC:60:2E:84:87","hostName":"ipAddress","192.168.1.17":"ipV6Address","":"active","alias":"Windows 10","interfaceType":"Wifi50"}`. The problem here is there's no value for the field `hostName`, which results in the field `ipAddress` being set it's value, which results in malforming the whole device object. This also was causing the whole connection to abort, resulting in a malformed JSON with no end.
For fixing this I'm removing the `Connection` header, as it will make the whole connection to abort.

There's also the problem with the malformed device, which I fixed by adding a `DeviceInfoListAdapterFactory` which removes the wrong device from the list, and continues reading after that.