### PR TITLE
Avoid models' obfuscation

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,16 +1,21 @@
-  # Livebox SDK ProGuard Rules
-  # Keep all SDK classes to prevent obfuscation issues with Moshi/Retrofit
-  -keep class es.masorange.livebox.sdk.** { *; }
-  -keepclassmembers class es.masorange.livebox.sdk.** { *; }
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
 
-  # Keep Moshi annotations
-  -keepclassmembers class es.masorange.livebox.sdk.** {
-      @com.squareup.moshi.* <fields>;
-  }
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
 
-  # Keep generated JsonAdapters
-  -if class es.masorange.livebox.sdk.**
-  -keep class <1>JsonAdapter {
-      <init>(...);
-      <fields>;
-  }
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/livebox-sdk/consumer-rules.pro
+++ b/livebox-sdk/consumer-rules.pro
@@ -1,0 +1,18 @@
+# Livebox SDK ProGuard Rules
+# These rules are automatically applied to projects that consume this SDK
+
+# Keep all SDK classes to prevent obfuscation issues with Moshi/Retrofit
+-keep class es.masorange.livebox.sdk.** { *; }
+-keepclassmembers class es.masorange.livebox.sdk.** { *; }
+
+# Keep Moshi annotations
+-keepclassmembers class es.masorange.livebox.sdk.** {
+    @com.squareup.moshi.* <fields>;
+}
+
+# Keep generated JsonAdapters
+-if class es.masorange.livebox.sdk.**
+-keep class <1>JsonAdapter {
+    <init>(...);
+    <fields>;
+}


### PR DESCRIPTION
Avoid SDK's models obfuscation when building release apks with minify.