### PR TITLE
Add WiFi60 to Interface types

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "es.masorange.livebox.sdk"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 8
-        versionName = "1.1.6"
+        versionCode = 9
+        versionName = "1.1.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/domain/livebox/models/DeviceDetail.kt
+++ b/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/domain/livebox/models/DeviceDetail.kt
@@ -68,6 +68,7 @@ data class DeviceDetail(
         @Json(name = "Ethernet") ETHERNET("Ethernet"),
         @Json(name = "Wifi") WIFI("Wifi"),
         @Json(name = "Wifi24") WIFI24("Wifi24"),
-        @Json(name = "Wifi50") WIFI50("Wifi50")
+        @Json(name = "Wifi50") WIFI50("Wifi50"),
+        @Json(name = "Wifi60") WIFI60("Wifi60")
     }
 }

--- a/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/domain/livebox/models/DeviceInfo.kt
+++ b/livebox-sdk/src/main/kotlin/es/masorange/livebox/sdk/domain/livebox/models/DeviceInfo.kt
@@ -26,6 +26,7 @@ data class DeviceInfo(
         @Json(name = "Ethernet") ETHERNET("Ethernet"),
         @Json(name = "Wifi") WIFI("Wifi"),
         @Json(name = "Wifi24") WIFI24("Wifi24"),
-        @Json(name = "Wifi50") WIFI50("Wifi50")
+        @Json(name = "Wifi50") WIFI50("Wifi50"),
+        @Json(name = "Wifi60") WIFI60("Wifi60")
     }
 }


### PR DESCRIPTION
Some Livebox 7 devices are sending WiFi60 interface types, which were breaking when parsing the JSON.